### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server implementation for the [SourceSync.ai](https://sourcesync.ai) API. This server allows AI models to interact with SourceSync.ai's knowledge management platform through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/3llggpfti7">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/3llggpfti7/badge" alt="SourceSync.ai Server MCP server" />
+</a>
+
 ## Features
 
 - Manage namespaces for organizing knowledge


### PR DESCRIPTION
This PR adds a badge for the [SourceSync.ai MCP Server](https://glama.ai/mcp/servers/3llggpfti7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/3llggpfti7">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/3llggpfti7/badge" alt="SourceSync.ai Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.